### PR TITLE
채권 등급별 분류 리스트 API 추가

### DIFF
--- a/src/main/kotlin/com/catches/securities_api/adapter/in/web/BondController.kt
+++ b/src/main/kotlin/com/catches/securities_api/adapter/in/web/BondController.kt
@@ -54,7 +54,8 @@ data class BondController(
                         BondRankResponseBody(
                             name = bond.name,
                             surfaceInterestRate = bond.surfaceInterestRate,
-                            expiredDate = bond.expiredDate
+                            expiredDate = bond.expiredDate,
+                            grade = bond.grade
                         )
                     }
                 )

--- a/src/main/kotlin/com/catches/securities_api/adapter/in/web/BondController.kt
+++ b/src/main/kotlin/com/catches/securities_api/adapter/in/web/BondController.kt
@@ -1,20 +1,17 @@
 package com.catches.securities_api.adapter.`in`.web
 
-import com.catches.securities_api.adapter.`in`.web.response.BondResponse
-import com.catches.securities_api.adapter.`in`.web.response.MetaBody
-import com.catches.securities_api.adapter.`in`.web.response.ResponseBody
-import com.catches.securities_api.application.port.out.BondPort
+import com.catches.securities_api.adapter.`in`.web.response.*
+import com.catches.securities_api.application.port.`in`.BondUseCase
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
-import java.math.BigDecimal
 import java.math.RoundingMode
 
 @RestController
 data class BondController(
-    private val bondPort: BondPort
+    private val bondUseCase: BondUseCase,
 ) {
 
     @ResponseStatus(HttpStatus.OK)
@@ -22,7 +19,7 @@ data class BondController(
     fun getBondList(
         @RequestParam("name") name: String
     ): ResponseBody {
-        val data = bondPort.getBondSimpleInfo(name)
+        val data = bondUseCase.getBondSimpleInfo(name)
 
         return ResponseBody(
             meta = MetaBody(200, "Success"),
@@ -37,6 +34,29 @@ data class BondController(
                     interestType = it.interestType,
                     price = it.price.toInt(),
                     priceDate = it.priceDate
+                )
+            }
+        )
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/bond/list")
+    fun getBondList(
+    ): ResponseBody {
+        val data = bondUseCase.getBondListGroupByGrade()
+
+        return ResponseBody(
+            meta = MetaBody(200, "Success"),
+            data = data.map {
+                BondRankResponse(
+                    grade = it.grade,
+                    bondList = it.bondList.map { bond ->
+                        BondRankResponseBody(
+                            name = bond.name,
+                            surfaceInterestRate = bond.surfaceInterestRate,
+                            expiredDate = bond.expiredDate
+                        )
+                    }
                 )
             }
         )

--- a/src/main/kotlin/com/catches/securities_api/adapter/in/web/response/BondResponse.kt
+++ b/src/main/kotlin/com/catches/securities_api/adapter/in/web/response/BondResponse.kt
@@ -14,3 +14,14 @@ data class BondResponse(
     val price: Int, // 종가
     val priceDate: String, // 종가 일자
 )
+
+data class BondRankResponse(
+    val grade: String,
+    val bondList: List<BondRankResponseBody>,
+)
+
+data class BondRankResponseBody(
+    val name: String,
+    val surfaceInterestRate: Double,
+    val expiredDate: String
+)

--- a/src/main/kotlin/com/catches/securities_api/adapter/in/web/response/BondResponse.kt
+++ b/src/main/kotlin/com/catches/securities_api/adapter/in/web/response/BondResponse.kt
@@ -23,5 +23,6 @@ data class BondRankResponse(
 data class BondRankResponseBody(
     val name: String,
     val surfaceInterestRate: Double,
-    val expiredDate: String
+    val expiredDate: String,
+    val grade: String
 )

--- a/src/main/kotlin/com/catches/securities_api/adapter/out/persistence/BondPersistenceAdapter.kt
+++ b/src/main/kotlin/com/catches/securities_api/adapter/out/persistence/BondPersistenceAdapter.kt
@@ -1,6 +1,8 @@
 package com.catches.securities_api.adapter.out.persistence
 
+import com.catches.securities_api.adapter.out.persistence.repository.BondGradeRankRepository
 import com.catches.securities_api.adapter.out.persistence.repository.BondRepository
+import com.catches.securities_api.application.port.`in`.dto.BondRankInDto
 import com.catches.securities_api.application.port.out.BondPort
 import com.catches.securities_api.application.port.`in`.dto.BondSimpleDto
 import org.springframework.stereotype.Component
@@ -8,7 +10,8 @@ import java.lang.StringBuilder
 
 @Component
 class BondPersistenceAdapter(
-    private val bondRepository: BondRepository
+    private val bondRepository: BondRepository,
+    private val bondGradeRankRepository: BondGradeRankRepository
 ): BondPort {
 
     override fun getBondSimpleInfo(name: String): BondSimpleDto? {
@@ -31,6 +34,18 @@ class BondPersistenceAdapter(
                     }
                 )
             }
+        }
+    }
+
+    override fun getBondListGroupByGrade(): List<BondRankInDto> {
+        return bondGradeRankRepository.findAllByOrderByGradeAscRankAsc().map {
+            BondRankInDto(
+                bondName = it.isinCodeName,
+                surfaceInterestRate = it.surfaceInterestRate,
+                expiredDate = it.expiredDate,
+                grade = it.grade,
+                rank = it.rank
+            )
         }
     }
 }

--- a/src/main/kotlin/com/catches/securities_api/adapter/out/persistence/repository/BondGradeRankRepository.kt
+++ b/src/main/kotlin/com/catches/securities_api/adapter/out/persistence/repository/BondGradeRankRepository.kt
@@ -1,12 +1,11 @@
 package com.catches.securities_api.adapter.out.persistence.repository
 
-import com.catches.securities_api.domain.Bond
+import com.catches.securities_api.domain.BondGradeRank
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface BondRepository: JpaRepository<Bond, String> {
+interface BondGradeRankRepository: JpaRepository<BondGradeRank, String> {
 
-    fun findByIsinCodeNameLike(name: String): List<Bond>?
-
+    fun findAllByOrderByGradeAscRankAsc(): List<BondGradeRank>
 }

--- a/src/main/kotlin/com/catches/securities_api/application/BondService.kt
+++ b/src/main/kotlin/com/catches/securities_api/application/BondService.kt
@@ -1,8 +1,11 @@
 package com.catches.securities_api.application
 
+import com.catches.securities_api.application.enum.GradeGroup
 import com.catches.securities_api.application.port.`in`.BondUseCase
 import com.catches.securities_api.application.port.`in`.dto.BondSimpleDto
 import com.catches.securities_api.application.port.out.BondPort
+import com.catches.securities_api.application.port.out.dto.BondRankBody
+import com.catches.securities_api.application.port.out.dto.BondRankOutDto
 import org.springframework.stereotype.Service
 
 @Service
@@ -12,5 +15,23 @@ class BondService(
 
     override fun getBondSimpleInfo(name: String): BondSimpleDto? {
         return bondPort.getBondSimpleInfo(name)
+    }
+
+    override fun getBondListGroupByGrade(): List<BondRankOutDto> {
+        val data = bondPort.getBondListGroupByGrade()
+
+        return data.groupBy { GradeGroup.fromGrade(it.grade) }.toSortedMap().map {
+            BondRankOutDto(
+                grade = GradeGroup.convertGradeRange(it.key),
+                bondList = it.value.map { bond ->
+                    BondRankBody(
+                        name = bond.bondName,
+                        surfaceInterestRate = bond.surfaceInterestRate.toDouble(),
+                        grade = bond.grade,
+                        expiredDate = bond.expiredDate.toString()
+                    )
+                }.sortedByDescending { it.surfaceInterestRate }.take(3)
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/catches/securities_api/application/enum/GradeGroup.kt
+++ b/src/main/kotlin/com/catches/securities_api/application/enum/GradeGroup.kt
@@ -1,0 +1,25 @@
+package com.catches.securities_api.application.enum
+
+enum class GradeGroup(val grades: Set<String>) {
+    AAA(setOf("AAA")),
+    AA(setOf("AA+", "AA", "AA-")),
+    A(setOf("A+", "A", "A-")),
+    BBB(setOf("BBB+", "BBB", "BBB-")),
+    OTHER(emptySet());
+
+    companion object {
+        fun fromGrade(grade: String): GradeGroup {
+            return values().find { it.grades.contains(grade) } ?: OTHER
+        }
+
+        fun convertGradeRange(gradeGroup: GradeGroup): String {
+            return when (gradeGroup) {
+                AAA -> "AAA"
+                AA -> "AA+ ~ AA-"
+                A -> "A+ ~ A-"
+                BBB -> "BBB+ ~ BBB-"
+                OTHER -> "이하 등급"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/catches/securities_api/application/port/in/BondUseCase.kt
+++ b/src/main/kotlin/com/catches/securities_api/application/port/in/BondUseCase.kt
@@ -1,9 +1,12 @@
 package com.catches.securities_api.application.port.`in`
 
 import com.catches.securities_api.application.port.`in`.dto.BondSimpleDto
+import com.catches.securities_api.application.port.out.dto.BondRankOutDto
 
 interface BondUseCase {
 
     fun getBondSimpleInfo(name: String): BondSimpleDto?
+
+    fun getBondListGroupByGrade(): List<BondRankOutDto>
 
 }

--- a/src/main/kotlin/com/catches/securities_api/application/port/in/dto/BondInDto.kt
+++ b/src/main/kotlin/com/catches/securities_api/application/port/in/dto/BondInDto.kt
@@ -14,3 +14,11 @@ data class BondSimpleDto(
     val price: BigDecimal, // 종가
     val priceDate: String, // 종가 일자
 )
+
+data class BondRankInDto(
+    val bondName: String,
+    val surfaceInterestRate: BigDecimal,
+    val expiredDate: LocalDate,
+    val grade: String,
+    val rank: Int,
+)

--- a/src/main/kotlin/com/catches/securities_api/application/port/out/BondPort.kt
+++ b/src/main/kotlin/com/catches/securities_api/application/port/out/BondPort.kt
@@ -1,8 +1,11 @@
 package com.catches.securities_api.application.port.out
 
+import com.catches.securities_api.application.port.`in`.dto.BondRankInDto
 import com.catches.securities_api.application.port.`in`.dto.BondSimpleDto
 
 interface BondPort {
 
     fun getBondSimpleInfo(name: String): BondSimpleDto?
+
+    fun getBondListGroupByGrade(): List<BondRankInDto>
 }

--- a/src/main/kotlin/com/catches/securities_api/application/port/out/dto/BondOutDto.kt
+++ b/src/main/kotlin/com/catches/securities_api/application/port/out/dto/BondOutDto.kt
@@ -1,0 +1,13 @@
+package com.catches.securities_api.application.port.out.dto
+
+data class BondRankOutDto(
+    val grade: String,
+    val bondList: List<BondRankBody>,
+)
+
+data class BondRankBody(
+    val name: String,
+    val surfaceInterestRate: Double,
+    val grade: String,
+    val expiredDate: String
+)

--- a/src/main/kotlin/com/catches/securities_api/domain/BondGradeRank.kt
+++ b/src/main/kotlin/com/catches/securities_api/domain/BondGradeRank.kt
@@ -1,0 +1,36 @@
+package com.catches.securities_api.domain
+
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import jakarta.persistence.*
+import java.time.LocalDate
+
+@Entity
+@Table(name = "bond_grade_rank")
+data class BondGradeRank(
+
+    @Column(name = "grade", nullable = false, length = 5)
+    var grade: String,
+
+    @Column(name = "rank", nullable = false)
+    var rank: Int,
+
+    @Id
+    @Column(name = "isin_code", nullable = false, length = 12)
+    var isinCode: String,
+
+    @Column(name = "isin_code_name", nullable = false, length = 100)
+    var isinCodeName: String,
+
+    @Column(name = "surface_interest_rate", nullable = false, precision = 15, scale = 10)
+    var surfaceInterestRate: BigDecimal,
+
+    @Column(name = "expired_date", nullable = false)
+    var expiredDate: LocalDate,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/src/test/resources/db/init/init.sql
+++ b/src/test/resources/db/init/init.sql
@@ -65,8 +65,11 @@ CREATE TABLE user_bond_info(
 
 CREATE TABLE bond_grade_rank (
     grade VARCHAR(5) not null, -- 기업 신용등급,
-    rank tinyint(1) not null, -- grade 별 랭킹
+    `rank` TINYINT not null, -- grade 별 랭킹
     isin_code VARCHAR(12) PRIMARY KEY NOT NULL, -- 법인등록번호,
+    isin_code_name VARCHAR(100) NOT NULL, -- 국제 채권 식별 번호 명칭
+    surface_interest_rate DECIMAL(15,10) NOT NULL, -- 채권 표면 이자율
+    expired_date DATE NOT NULL, -- 채권 만기 일자
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
 );

--- a/src/test/resources/db/init/init.sql
+++ b/src/test/resources/db/init/init.sql
@@ -62,3 +62,11 @@ CREATE TABLE user_bond_info(
     FOREIGN KEY(user_id) REFERENCES user(id),
     FOREIGN KEY(bond_id) REFERENCES bond(isin_code)
 );
+
+CREATE TABLE bond_grade_rank (
+    grade VARCHAR(5) not null, -- 기업 신용등급,
+    rank tinyint(1) not null, -- grade 별 랭킹
+    isin_code VARCHAR(12) PRIMARY KEY NOT NULL, -- 법인등록번호,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL
+);


### PR DESCRIPTION
#7 채권 리스트 API 구현

- 각 등급별 수익률이 좋은 채권 리스트를 반환하는 API를 구현하였습니다.
- AAA, AAA+ ~ AAA-, AA+ ~ AA-, A+ ~ A-, BBB+ ~ BBB-, 이하 등급 분류로 반환합니다.
- 각 채권 리스트는 3개씩 반환합니다.