### PR TITLE
채권 이름 like 검색 api 작성

### DIFF
--- a/src/main/kotlin/com/catches/securities_api/adapter/in/web/BondController.kt
+++ b/src/main/kotlin/com/catches/securities_api/adapter/in/web/BondController.kt
@@ -14,15 +14,6 @@ data class BondController(
     private val bondUseCase: BondUseCase,
 ) {
 
-    // TODO SearchBondList를 하여 채권 이름으로 검색 할수 있는 API로 처리해야 한다.
-    /**
-     * TODO
-     * flow
-     *  1. 채권 이름으로 like 검색을 하여 채권 이름 리스트를 가져온다.
-     *  2. 텔레그램 메시지에서 해당 리스트를 선택할수 있는 메시지를 보여준다.
-     *  3. 메시지가 선택이 되면 해당 채권에 대한 정보를 가져온다.
-     *  -> 등록도 채권을 먼저 검색하고 등록하도록 만들어야 할것 같다.
-     */
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/bond")
     fun getBondList(
@@ -33,6 +24,31 @@ data class BondController(
         return ResponseBody(
             meta = MetaBody(200, "Success"),
             data = data?.let {
+                BondResponse(
+                    bondName = it!!.bondName,
+                    surfaceInterestRate = it.surfaceInterestRate.setScale(2, RoundingMode.DOWN).toDouble(),
+                    issuerName = it.issuerName,
+                    issueDate = it.issueDate.toString(),
+                    expiredDate = it.expiredDate.toString(),
+                    interestChange = it.interestChange,
+                    interestType = it.interestType,
+                    price = it.price.toInt(),
+                    priceDate = it.priceDate
+                )
+            }
+        )
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/bond/search")
+    fun searchBondList(
+        @RequestParam("name") name: String
+    ): ResponseBody {
+        val data = bondUseCase.searchBondList(name)
+
+        return ResponseBody(
+            meta = MetaBody(200, "Success"),
+            data = data.map {
                 BondResponse(
                     bondName = it!!.bondName,
                     surfaceInterestRate = it.surfaceInterestRate.setScale(2, RoundingMode.DOWN).toDouble(),

--- a/src/main/kotlin/com/catches/securities_api/adapter/out/persistence/BondPersistenceAdapter.kt
+++ b/src/main/kotlin/com/catches/securities_api/adapter/out/persistence/BondPersistenceAdapter.kt
@@ -37,6 +37,27 @@ class BondPersistenceAdapter(
         }
     }
 
+    override fun findBondList(name: String): List<BondSimpleDto> {
+        val likeName = StringBuilder().append("%").append(name).append("%").toString()
+        return bondRepository.findByIsinCodeNameLike(likeName)?.map { bond ->
+            BondSimpleDto(
+                bondName = bond.isinCodeName,
+                surfaceInterestRate = bond.surfaceInterestRate,
+                issuerName = bond.issuer.name,
+                issueDate = bond.issueDate,
+                expiredDate = bond.expiredDate,
+                interestChange = bond.interestChange.name,
+                interestType = bond.interestType.name,
+                price = bond.price?: 0.toBigDecimal(),
+                priceDate = bond.pricedDate.let { date ->
+                    date?.let {
+                        bond.toString()
+                    } ?: ""
+                }
+            )
+        }?: emptyList()
+    }
+
     override fun getBondListGroupByGrade(): List<BondRankInDto> {
         return bondGradeRankRepository.findAllByOrderByGradeAscRankAsc().map {
             BondRankInDto(

--- a/src/main/kotlin/com/catches/securities_api/application/BondService.kt
+++ b/src/main/kotlin/com/catches/securities_api/application/BondService.kt
@@ -17,6 +17,10 @@ class BondService(
         return bondPort.getBondSimpleInfo(name)
     }
 
+    override fun searchBondList(name: String): List<BondSimpleDto> {
+        return bondPort.findBondList(name)
+    }
+
     override fun getBondListGroupByGrade(): List<BondRankOutDto> {
         val data = bondPort.getBondListGroupByGrade()
 

--- a/src/main/kotlin/com/catches/securities_api/application/port/in/BondUseCase.kt
+++ b/src/main/kotlin/com/catches/securities_api/application/port/in/BondUseCase.kt
@@ -7,6 +7,8 @@ interface BondUseCase {
 
     fun getBondSimpleInfo(name: String): BondSimpleDto?
 
+    fun searchBondList(name: String): List<BondSimpleDto>
+
     fun getBondListGroupByGrade(): List<BondRankOutDto>
 
 }

--- a/src/main/kotlin/com/catches/securities_api/application/port/out/BondPort.kt
+++ b/src/main/kotlin/com/catches/securities_api/application/port/out/BondPort.kt
@@ -7,5 +7,7 @@ interface BondPort {
 
     fun getBondSimpleInfo(name: String): BondSimpleDto?
 
+    fun findBondList(name: String): List<BondSimpleDto>
+
     fun getBondListGroupByGrade(): List<BondRankInDto>
 }


### PR DESCRIPTION
#13 채권이름으로 리스트 검색하는 API 추가

 - 채권 이름으로 해당되는 like 검색. 리스트 반환하는 API 추가입니다.

-> 메시지 레포지토리에서 버튼 유형으로 콜백처리시 데이터 양 문제가 발생하는데 어떻게 처리할지 고민이 필요합니다.